### PR TITLE
build: use external golangci-lint module

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains the code for the demo presented in the talk "Rethinking CI/CD: A Leap Beyond Bash and YAML" at [DevConf.CZ 2024](https://www.devconf.info/cz/).
 
+Slides for the talk can be found [here](https://aweris.me/slides/2024-06-13-devconf-cz-rethinking-cicd/).
+
 ## Quick Start
 
 Just run the following command to build and run the demo:

--- a/dagger.json
+++ b/dagger.json
@@ -1,6 +1,12 @@
 {
   "name": "ci",
   "sdk": "go",
+  "dependencies": [
+    {
+      "name": "golangci-lint",
+      "source": "github.com/sagikazarmark/daggerverse/golangci-lint@4341f097b207ddcb180817a6a3fe974947a47490"
+    }
+  ],
   "source": "dagger",
   "engineVersion": "v0.11.6",
   "views": [

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -100,11 +100,12 @@ func (m *Ci) Lint(
 	// +default="v1.59.0"
 	linterVersion string,
 ) *Container {
-	return m.container().
-		WithMountedFile("/tmp/golangci-lint/install.sh", dag.HTTP("https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh")).
-		WithExec([]string{"chmod", "+x", "/tmp/golangci-lint/install.sh"}).
-		WithExec([]string{"/tmp/golangci-lint/install.sh", "-b", "/usr/local/bin", linterVersion}).
-		WithExec([]string{"golangci-lint", "run"})
+	var (
+		moduleOpts = GolangciLintOpts{Version: linterVersion, GoVersion: m.GoVersion}
+		runOpts    = GolangciLintRunOpts{Verbose: true}
+	)
+
+	return dag.GolangciLint(moduleOpts).Run(m.Source, runOpts)
 }
 
 // Runs the ci pipeline.


### PR DESCRIPTION
This PR:

- replaces golangci-lint target with external [golangci-lint](https://daggerverse.dev/mod/github.com/sagikazarmark/daggerverse/golangci-lint@4341f097b207ddcb180817a6a3fe974947a47490) module

With this now we can reuse modules from https://daggerverse.dev instead of maintaining them in our project.